### PR TITLE
bugfix - asset path url

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,22 +4,22 @@
 
 <title>{{ page.title }} - {{ site.title }}</title>
 
-<link rel="apple-touch-icon" sizes="57x57" href="{{ site.url }}assets/favicons/apple-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="60x60" href="{{ site.url }}assets/favicons/apple-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="72x72" href="{{ site.url }}assets/favicons/apple-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="76x76" href="{{ site.url }}assets/favicons/apple-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="114x114" href="{{ site.url }}assets/favicons/apple-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="120x120" href="{{ site.url }}assets/favicons/apple-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="144x144" href="{{ site.url }}assets/favicons/apple-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="152x152" href="{{ site.url }}assets/favicons/apple-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="{{ site.url }}assets/favicons/apple-icon-180x180.png">
-<link rel="icon" type="image/png" sizes="192x192"  href="{{ site.url }}assets/favicons/android-icon-192x192.png">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ site.url }}assets/favicons/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="96x96" href="{{ site.url }}assets/favicons/favicon-96x96.png">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}assets/favicons/favicon-16x16.png">
-<link rel="shortcut icon" type="image/png" href="{{ site.url }}assets/favicons/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="57x57" href="{{ site.url }}/assets/favicons/apple-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="{{ site.url }}/assets/favicons/apple-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="{{ site.url }}/assets/favicons/apple-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="{{ site.url }}/assets/favicons/apple-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="{{ site.url }}/assets/favicons/apple-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="{{ site.url }}/assets/favicons/apple-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="{{ site.url }}/assets/favicons/apple-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="{{ site.url }}/assets/favicons/apple-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ site.url }}/assets/favicons/apple-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="192x192"  href="{{ site.url }}/assets/favicons/android-icon-192x192.png">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ site.url }}/assets/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="96x96" href="{{ site.url }}/assets/favicons/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}/assets/favicons/favicon-16x16.png">
+<link rel="shortcut icon" type="image/png" href="{{ site.url }}/assets/favicons/favicon-16x16.png">
 <link rel="chrome icon" type="image/png" href="/apple-icon.png">
-<link rel="manifest" href="{{ site.url }}assets/favicons/manifest.json">
+<link rel="manifest" href="{{ site.url }}/assets/favicons/manifest.json">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
I noticed a couple errors in the console relating to pathing.
<img width="536" alt="Screen Shot 2020-01-16 at 4 09 39 PM" src="https://user-images.githubusercontent.com/54607724/72570667-bdd15680-387a-11ea-836b-76aeb023a752.png">
